### PR TITLE
Move to Netty5 package names

### DIFF
--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>netty-codec-haproxy</artifactId>
-    <version>${parent.version}</version>
+    <version>${project.parent.version}</version>
     <name>Netty/Codec/HAProxy</name>
     <packaging>jar</packaging>
 
@@ -22,22 +22,22 @@
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
+            <artifactId>netty5-common</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
+            <artifactId>netty5-buffer</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
+            <artifactId>netty5-transport</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
+            <artifactId>netty5-codec</artifactId>
             <version>${netty.version}</version>
         </dependency>
 

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
@@ -17,16 +17,16 @@ package io.netty.contrib.handler.codec.haproxy;
 
 import static java.util.Objects.requireNonNull;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.ByteBuf;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
-import io.netty.util.AbstractReferenceCounted;
-import io.netty.util.ByteProcessor;
-import io.netty.util.CharsetUtil;
-import io.netty.util.NetUtil;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetectorFactory;
-import io.netty.util.ResourceLeakTracker;
-import io.netty.util.internal.StringUtil;
+import io.netty5.util.AbstractReferenceCounted;
+import io.netty5.util.ByteProcessor;
+import io.netty5.util.CharsetUtil;
+import io.netty5.util.NetUtil;
+import io.netty5.util.ResourceLeakDetector;
+import io.netty5.util.ResourceLeakDetectorFactory;
+import io.netty5.util.ResourceLeakTracker;
+import io.netty5.util.internal.StringUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -15,11 +15,11 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.ProtocolDetectionResult;
-import io.netty.util.CharsetUtil;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.ByteToMessageDecoder;
+import io.netty5.handler.codec.ProtocolDetectionResult;
+import io.netty5.util.CharsetUtil;
 
 
 import static io.netty.contrib.handler.codec.haproxy.HAProxyConstants.*;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -15,12 +15,12 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
-import io.netty.util.CharsetUtil;
-import io.netty.util.NetUtil;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.ChannelHandler.Sharable;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.MessageToByteEncoder;
+import io.netty5.util.CharsetUtil;
+import io.netty5.util.NetUtil;
 
 import java.util.List;
 

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyProtocolException.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyProtocolException.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.handler.codec.DecoderException;
+import io.netty5.handler.codec.DecoderException;
 
 /**
  * A {@link DecoderException} which is thrown when an invalid HAProxy proxy protocol header is encountered

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.util.internal.StringUtil;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.Unpooled;
+import io.netty5.util.internal.StringUtil;
 
 import java.util.Collections;
 import java.util.List;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DefaultByteBufHolder;
-import io.netty.util.internal.StringUtil;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.DefaultByteBufHolder;
+import io.netty5.util.internal.StringUtil;
 
 import static java.util.Objects.requireNonNull;
 

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -15,18 +15,18 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.local.LocalAddress;
-import io.netty.channel.local.LocalChannel;
-import io.netty.channel.local.LocalHandler;
-import io.netty.channel.local.LocalServerChannel;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.channel.Channel;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.SimpleChannelInboundHandler;
+import io.netty5.channel.local.LocalAddress;
+import io.netty5.channel.local.LocalChannel;
+import io.netty5.channel.local.LocalHandler;
+import io.netty5.channel.local.LocalServerChannel;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -15,21 +15,21 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.ProtocolDetectionResult;
-import io.netty.handler.codec.ProtocolDetectionState;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.channel.embedded.EmbeddedChannel;
+import io.netty5.handler.codec.ProtocolDetectionResult;
+import io.netty5.handler.codec.ProtocolDetectionState;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.TransportProtocol;
-import io.netty.util.CharsetUtil;
-import io.netty.util.concurrent.Future;
+import io.netty5.util.CharsetUtil;
+import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.netty.buffer.Unpooled.buffer;
-import static io.netty.buffer.Unpooled.copiedBuffer;
+import static io.netty5.buffer.Unpooled.buffer;
+import static io.netty5.buffer.Unpooled.copiedBuffer;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -15,13 +15,13 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufUtil;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty.contrib.handler.codec.haproxy.HAProxyTLV.Type;
-import io.netty.util.ByteProcessor;
-import io.netty.util.CharsetUtil;
+import io.netty5.util.ByteProcessor;
+import io.netty5.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>netty-codec-haproxy-examples</artifactId>
-    <version>${parent.version}</version>
+    <version>${project.parent.version}</version>
 
     <dependencies>
         <dependency>
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
+            <artifactId>netty5-handler</artifactId>
             <version>${netty.version}</version>
         </dependency>
     </dependencies>

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
@@ -15,18 +15,18 @@
  */
 package io.netty.contrib.handler.codec.haproxy.example;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.nio.NioHandler;
-import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty5.bootstrap.Bootstrap;
+import io.netty5.buffer.Unpooled;
+import io.netty5.channel.Channel;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.nio.NioSocketChannel;
 import io.netty.contrib.handler.codec.haproxy.HAProxyCommand;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessage;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol;
-import io.netty.util.CharsetUtil;
+import io.netty5.util.CharsetUtil;
 
 import static io.netty.contrib.handler.codec.haproxy.example.HAProxyServer.PORT;
 

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyHandler.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyHandler.java
@@ -15,11 +15,11 @@
  */
 package io.netty.contrib.handler.codec.haproxy.example;
 
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelHandler;
+import io.netty5.channel.ChannelHandlerContext;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessage;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessageEncoder;
-import io.netty.util.concurrent.Future;
+import io.netty5.util.concurrent.Future;
 
 public class HAProxyHandler implements ChannelHandler {
 

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
@@ -15,21 +15,21 @@
  */
 package io.netty.contrib.handler.codec.haproxy.example;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioHandler;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty5.bootstrap.ServerBootstrap;
+import io.netty5.buffer.ByteBuf;
+import io.netty5.buffer.ByteBufUtil;
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.channel.ChannelInitializer;
+import io.netty5.channel.EventLoopGroup;
+import io.netty5.channel.MultithreadEventLoopGroup;
+import io.netty5.channel.SimpleChannelInboundHandler;
+import io.netty5.channel.nio.NioHandler;
+import io.netty5.channel.socket.SocketChannel;
+import io.netty5.channel.socket.nio.NioServerSocketChannel;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessage;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessageDecoder;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
+import io.netty5.handler.logging.LogLevel;
+import io.netty5.handler.logging.LoggingHandler;
 
 public final class HAProxyServer {
 

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
     <profile>
       <id>leak</id>
       <properties>
-        <test.argLine>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</test.argLine>
+        <test.argLine>-Dio.netty5.leakDetectionLevel=paranoid -Dio.netty5.leakDetection.targetRecords=32</test.argLine>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Motivation:
Use the latest Netty 5 binaries.

Modifications:
Move to Netty 5 package names

Result:
Use the latest Netty 5 binaries.