### PR TITLE
Update to Netty 5.0.0.Alpha2-SNAPSHOT

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.haproxy;
 
 import static java.util.Objects.requireNonNull;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
 import io.netty5.util.AbstractReferenceCounted;
 import io.netty5.util.ByteProcessor;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.ProtocolDetectionResult;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.Collections;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.DefaultByteBufHolder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
 import io.netty5.util.internal.StringUtil;
 
 import static java.util.Objects.requireNonNull;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.ByteBuf;
+import io.netty.buffer.ByteBuf;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.ProtocolDetectionResult;
 import io.netty5.handler.codec.ProtocolDetectionState;
@@ -28,8 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static io.netty5.buffer.Unpooled.buffer;
-import static io.netty5.buffer.Unpooled.copiedBuffer;
+import static io.netty.buffer.Unpooled.buffer;
+import static io.netty.buffer.Unpooled.copiedBuffer;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.ByteBufUtil;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty.contrib.handler.codec.haproxy.HAProxyTLV.Type;
 import io.netty5.util.ByteProcessor;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.haproxy.example;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty5.buffer.Unpooled;
+import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
@@ -16,8 +16,8 @@
 package io.netty.contrib.handler.codec.haproxy.example;
 
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.buffer.ByteBuf;
-import io.netty5.buffer.ByteBufUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.EventLoopGroup;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.1.Alpha1-SNAPSHOT</netty.version>
+    <netty.version>5.0.0.Alpha2-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Final-SNAPSHOT</netty.version>
+    <netty.version>5.0.1.Alpha1-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

Use the latest changes from Netty 5 snapshot

Modifications:

- Update to Netty 5.0.0.Alpha2-SNAPSHOT
- Use ByteBuf from Netty 4

Result:

Use the latest changes from Netty 5 snapshot