### PR TITLE
Port codec-haproxy to Buffer API

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -137,7 +137,8 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoderForBuffer<H
             Buffer value = haProxyTLV.content();
             int readableBytes = value.readableBytes();
             out.writeShort((short) readableBytes);
-            out.writeBytes(value.copy(value.readerOffset(), readableBytes));
+            value.copyInto(value.readerOffset(), out, out.writerOffset(), readableBytes);
+            out.skipWritable(readableBytes);
         }
     }
 

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -15,10 +15,10 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoder;
+import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -32,7 +32,7 @@ import static io.netty.contrib.handler.codec.haproxy.HAProxyConstants.*;
  * @see <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
  */
 @Sharable
-public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMessage> {
+public final class HAProxyMessageEncoder extends MessageToByteEncoderForBuffer<HAProxyMessage> {
 
     private static final int V2_VERSION_BITMASK = 0x02 << 4;
 
@@ -46,7 +46,12 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, HAProxyMessage msg, ByteBuf out) throws Exception {
+    protected Buffer allocateBuffer(ChannelHandlerContext ctx, HAProxyMessage msg) {
+        return ctx.bufferAllocator().allocate(256);
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, HAProxyMessage msg, Buffer out) {
         switch (msg.protocolVersion()) {
             case V1:
                 encodeV1(msg, out);
@@ -59,7 +64,7 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
         }
     }
 
-    private static void encodeV1(HAProxyMessage msg, ByteBuf out) {
+    private static void encodeV1(HAProxyMessage msg, Buffer out) {
         out.writeBytes(TEXT_PREFIX);
         out.writeByte((byte) ' ');
         out.writeCharSequence(msg.proxiedProtocol().name(), CharsetUtil.US_ASCII);
@@ -75,9 +80,9 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
         out.writeByte((byte) '\n');
     }
 
-    private static void encodeV2(HAProxyMessage msg, ByteBuf out) {
+    private static void encodeV2(HAProxyMessage msg, Buffer out) {
         out.writeBytes(BINARY_PREFIX);
-        out.writeByte(V2_VERSION_BITMASK | msg.command().byteValue());
+        out.writeByte((byte) (V2_VERSION_BITMASK | msg.command().byteValue()));
         out.writeByte(msg.proxiedProtocol().byteValue());
 
         switch (msg.proxiedProtocol().addressFamily()) {
@@ -86,47 +91,57 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
                 byte[] srcAddrBytes = NetUtil.createByteArrayFromIpAddressString(msg.sourceAddress());
                 byte[] dstAddrBytes = NetUtil.createByteArrayFromIpAddressString(msg.destinationAddress());
                 // srcAddrLen + dstAddrLen + 4 (srcPort + dstPort) + numTlvBytes
-                out.writeShort(srcAddrBytes.length + dstAddrBytes.length + 4 + msg.tlvNumBytes());
+                out.writeShort((short) (srcAddrBytes.length + dstAddrBytes.length + 4 + msg.tlvNumBytes()));
                 out.writeBytes(srcAddrBytes);
                 out.writeBytes(dstAddrBytes);
-                out.writeShort(msg.sourcePort());
-                out.writeShort(msg.destinationPort());
+                out.writeShort((short) msg.sourcePort());
+                out.writeShort((short) msg.destinationPort());
                 encodeTlvs(msg.tlvs(), out);
                 break;
             case AF_UNIX:
-                out.writeShort(TOTAL_UNIX_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes());
-                int srcAddrBytesWritten = out.writeCharSequence(msg.sourceAddress(), CharsetUtil.US_ASCII);
-                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - srcAddrBytesWritten);
-                int dstAddrBytesWritten = out.writeCharSequence(msg.destinationAddress(), CharsetUtil.US_ASCII);
-                out.writeZero(UNIX_ADDRESS_BYTES_LENGTH - dstAddrBytesWritten);
+                out.writeShort((short) (TOTAL_UNIX_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes()));
+                int srcAddrBytesWritten = out.writerOffset();
+                out.writeCharSequence(msg.sourceAddress(), CharsetUtil.US_ASCII);
+                srcAddrBytesWritten = out.writerOffset() - srcAddrBytesWritten;
+                int length = UNIX_ADDRESS_BYTES_LENGTH - srcAddrBytesWritten;
+                for(int i = 0; i < length; ++i) {
+                    out.writeByte((byte) 0);
+                }
+                int dstAddrBytesWritten = out.writerOffset();
+                out.writeCharSequence(msg.destinationAddress(), CharsetUtil.US_ASCII);
+                dstAddrBytesWritten = out.writerOffset() - dstAddrBytesWritten;
+                length = UNIX_ADDRESS_BYTES_LENGTH - dstAddrBytesWritten;
+                for(int i = 0; i < length; ++i) {
+                    out.writeByte((byte) 0);
+                }
                 encodeTlvs(msg.tlvs(), out);
                 break;
             case AF_UNSPEC:
-                out.writeShort(0);
+                out.writeShort((short) 0);
                 break;
             default:
                 throw new HAProxyProtocolException("unexpected addrFamily");
         }
     }
 
-    private static void encodeTlv(HAProxyTLV haProxyTLV, ByteBuf out) {
+    private static void encodeTlv(HAProxyTLV haProxyTLV, Buffer out) {
         if (haProxyTLV instanceof HAProxySSLTLV) {
             HAProxySSLTLV ssltlv = (HAProxySSLTLV) haProxyTLV;
             out.writeByte(haProxyTLV.typeByteValue());
-            out.writeShort(ssltlv.contentNumBytes());
+            out.writeShort((short) ssltlv.contentNumBytes());
             out.writeByte(ssltlv.client());
             out.writeInt(ssltlv.verify());
             encodeTlvs(ssltlv.encapsulatedTLVs(), out);
         } else {
             out.writeByte(haProxyTLV.typeByteValue());
-            ByteBuf value = haProxyTLV.content();
+            Buffer value = haProxyTLV.content();
             int readableBytes = value.readableBytes();
-            out.writeShort(readableBytes);
-            out.writeBytes(value.readSlice(readableBytes));
+            out.writeShort((short) readableBytes);
+            out.writeBytes(value.copy(value.readerOffset(), readableBytes));
         }
     }
 
-    private static void encodeTlvs(List<HAProxyTLV> haProxyTLVs, ByteBuf out) {
+    private static void encodeTlvs(List<HAProxyTLV> haProxyTLVs, Buffer out) {
         for (int i = 0; i < haProxyTLVs.size(); i++) {
             encodeTlv(haProxyTLVs.get(i), out);
         }

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
@@ -15,12 +15,13 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
+
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 
 /**
  * Represents a {@link HAProxyTLV} of the type {@link HAProxyTLV.Type#PP2_TYPE_SSL}.
@@ -41,7 +42,7 @@ public final class HAProxySSLTLV extends HAProxyTLV {
      * @param tlvs the encapsulated {@link HAProxyTLV}s
      */
     public HAProxySSLTLV(final int verify, final byte clientBitField, final List<HAProxyTLV> tlvs) {
-        this(verify, clientBitField, tlvs, Unpooled.EMPTY_BUFFER);
+        this(verify, clientBitField, tlvs, preferredAllocator().allocate(0));
     }
 
     /**
@@ -53,7 +54,7 @@ public final class HAProxySSLTLV extends HAProxyTLV {
      * @param tlvs the encapsulated {@link HAProxyTLV}s
      * @param rawContent the raw TLV content
      */
-    HAProxySSLTLV(final int verify, final byte clientBitField, final List<HAProxyTLV> tlvs, final ByteBuf rawContent) {
+    HAProxySSLTLV(final int verify, final byte clientBitField, final List<HAProxyTLV> tlvs, final Buffer rawContent) {
         super(Type.PP2_TYPE_SSL, (byte) 0x20, rawContent);
 
         this.verify = verify;
@@ -120,5 +121,17 @@ public final class HAProxySSLTLV extends HAProxyTLV {
                ", client: " + client() +
                ", verify: " + verify() +
                ", numEncapsulatedTlvs: " + tlvs.size() + ')';
+    }
+
+    @Override
+    protected HAProxyTLV receive(Buffer buf) {
+        return new HAProxySSLTLV(verify, clientBitField, tlvs, buf);
+    }
+
+    Buffer content() {
+        if (!isAccessible()) {
+            throw new IllegalStateException("HAProxySSLTLV is closed.");
+        }
+        return getBuffer();
     }
 }

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.DefaultByteBufHolder;
+import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.api.BufferHolder;
 import io.netty5.util.internal.StringUtil;
 
 import static java.util.Objects.requireNonNull;
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see HAProxySSLTLV
  */
-public class HAProxyTLV extends DefaultByteBufHolder {
+public class HAProxyTLV extends BufferHolder<HAProxyTLV> {
 
     private final Type type;
     private final byte typeByteValue;
@@ -120,7 +120,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
      * @param typeByteValue the byteValue of the TLV. This is especially important if non-standard TLVs are used
      * @param content the raw content of the TLV
      */
-    public HAProxyTLV(byte typeByteValue, ByteBuf content) {
+    public HAProxyTLV(byte typeByteValue, Buffer content) {
         this(Type.typeForByteValue(typeByteValue), typeByteValue, content);
     }
 
@@ -130,7 +130,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
      * @param type the {@link Type} of the TLV
      * @param content the raw content of the TLV
      */
-    public HAProxyTLV(Type type, ByteBuf content) {
+    public HAProxyTLV(Type type, Buffer content) {
         this(type, Type.byteValueForType(type), content);
     }
 
@@ -141,7 +141,7 @@ public class HAProxyTLV extends DefaultByteBufHolder {
      * @param typeByteValue the byteValue of the TLV. This is especially important if non-standard TLVs are used
      * @param content the raw content of the TLV
      */
-    HAProxyTLV(final Type type, final byte typeByteValue, final ByteBuf content) {
+    HAProxyTLV(final Type type, final byte typeByteValue, final Buffer content) {
         super(content);
         requireNonNull(type, "type");
 
@@ -164,54 +164,22 @@ public class HAProxyTLV extends DefaultByteBufHolder {
     }
 
     @Override
-    public HAProxyTLV copy() {
-        return replace(content().copy());
-    }
-
-    @Override
-    public HAProxyTLV duplicate() {
-        return replace(content().duplicate());
-    }
-
-    @Override
-    public HAProxyTLV retainedDuplicate() {
-        return replace(content().retainedDuplicate());
-    }
-
-    @Override
-    public HAProxyTLV replace(ByteBuf content) {
-        return new HAProxyTLV(type, typeByteValue, content);
-    }
-
-    @Override
-    public HAProxyTLV retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public HAProxyTLV retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public HAProxyTLV touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public HAProxyTLV touch(Object hint) {
-        super.touch(hint);
-        return this;
-    }
-
-    @Override
     public String toString() {
         return StringUtil.simpleClassName(this) +
                "(type: " + type() +
                ", typeByteValue: " + typeByteValue() +
-               ", content: " + contentToString() + ')';
+               ", content: " + content() + ')';
+    }
+
+    @Override
+    protected HAProxyTLV receive(Buffer buf) {
+        return new HAProxyTLV(type, typeByteValue, buf);
+    }
+
+    Buffer content() {
+        if (!isAccessible()) {
+            throw new IllegalStateException("HAProxyTLV is closed.");
+        }
+        return getBuffer();
     }
 }

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -15,53 +15,44 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HAProxySSLTLVTest {
 
     @Test
-    public void testClientBitmask() throws Exception {
+    public void testClientBitmask() {
 
         // 0b0000_0111
         final byte allClientsEnabled = 0x7;
-        final HAProxySSLTLV allClientsEnabledTLV =
-                new HAProxySSLTLV(0, allClientsEnabled, Collections.emptyList(), Unpooled.buffer());
-
-        assertTrue(allClientsEnabledTLV.isPP2ClientCertConn());
-        assertTrue(allClientsEnabledTLV.isPP2ClientSSL());
-        assertTrue(allClientsEnabledTLV.isPP2ClientCertSess());
-
-        assertTrue(allClientsEnabledTLV.release());
+        try (HAProxySSLTLV allClientsEnabledTLV = new HAProxySSLTLV(0, allClientsEnabled,
+                Collections.emptyList(), preferredAllocator().allocate(0))) {
+            assertTrue(allClientsEnabledTLV.isPP2ClientCertConn());
+            assertTrue(allClientsEnabledTLV.isPP2ClientSSL());
+            assertTrue(allClientsEnabledTLV.isPP2ClientCertSess());
+        }
 
         // 0b0000_0101
         final byte clientSSLandClientCertSessEnabled = 0x5;
+        try (HAProxySSLTLV clientSSLandClientCertSessTLV = new HAProxySSLTLV(0, clientSSLandClientCertSessEnabled,
+                Collections.emptyList(), preferredAllocator().allocate(0))) {
+            assertFalse(clientSSLandClientCertSessTLV.isPP2ClientCertConn());
+            assertTrue(clientSSLandClientCertSessTLV.isPP2ClientSSL());
+            assertTrue(clientSSLandClientCertSessTLV.isPP2ClientCertSess());
+        }
 
-        final HAProxySSLTLV clientSSLandClientCertSessTLV =
-                new HAProxySSLTLV(0, clientSSLandClientCertSessEnabled, Collections.emptyList(),
-                                  Unpooled.buffer());
-
-        assertFalse(clientSSLandClientCertSessTLV.isPP2ClientCertConn());
-        assertTrue(clientSSLandClientCertSessTLV.isPP2ClientSSL());
-        assertTrue(clientSSLandClientCertSessTLV.isPP2ClientCertSess());
-
-        assertTrue(clientSSLandClientCertSessTLV.release());
         // 0b0000_0000
         final byte noClientEnabled = 0x0;
-
-        final HAProxySSLTLV noClientTlv =
-                new HAProxySSLTLV(0, noClientEnabled, Collections.emptyList(),
-                                  Unpooled.buffer());
-
-        assertFalse(noClientTlv.isPP2ClientCertConn());
-        assertFalse(noClientTlv.isPP2ClientSSL());
-        assertFalse(noClientTlv.isPP2ClientCertSess());
-
-        assertTrue(noClientTlv.release());
+        try (HAProxySSLTLV noClientTlv = new HAProxySSLTLV(0, noClientEnabled, Collections.emptyList(),
+                preferredAllocator().allocate(0))) {
+            assertFalse(noClientTlv.isPP2ClientCertConn());
+            assertFalse(noClientTlv.isPP2ClientSSL());
+            assertFalse(noClientTlv.isPP2ClientCertSess());
+        }
     }
 }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.haproxy.example;
 
 import io.netty5.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty5.channel.Channel;
 import io.netty5.channel.EventLoopGroup;
 import io.netty5.channel.MultithreadEventLoopGroup;
@@ -26,9 +25,9 @@ import io.netty.contrib.handler.codec.haproxy.HAProxyCommand;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessage;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol;
-import io.netty5.util.CharsetUtil;
 
 import static io.netty.contrib.handler.codec.haproxy.example.HAProxyServer.PORT;
+import static io.netty5.buffer.ByteBufUtil.writeAscii;
 
 public final class HAProxyClient {
 
@@ -50,8 +49,8 @@ public final class HAProxyClient {
                     "127.0.0.1", "127.0.0.2", 8000, 9000);
 
             ch.writeAndFlush(message).sync();
-            ch.writeAndFlush(Unpooled.copiedBuffer("Hello World!", CharsetUtil.US_ASCII)).sync();
-            ch.writeAndFlush(Unpooled.copiedBuffer("Bye now!", CharsetUtil.US_ASCII)).sync();
+            ch.writeAndFlush(writeAscii(ch.bufferAllocator(), "Hello World!")).sync();
+            ch.writeAndFlush(writeAscii(ch.bufferAllocator(), "Bye now!")).sync();
             ch.close().sync();
         } finally {
             group.shutdownGracefully();

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
@@ -16,8 +16,7 @@
 package io.netty.contrib.handler.codec.haproxy.example;
 
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
+import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.EventLoopGroup;
@@ -30,6 +29,8 @@ import io.netty.contrib.handler.codec.haproxy.HAProxyMessage;
 import io.netty.contrib.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty5.handler.logging.LogLevel;
 import io.netty5.handler.logging.LoggingHandler;
+
+import static io.netty5.buffer.ByteBufUtil.appendPrettyHexDump;
 
 public final class HAProxyServer {
 
@@ -53,17 +54,22 @@ public final class HAProxyServer {
 
     static class HAProxyServerInitializer extends ChannelInitializer<SocketChannel> {
         @Override
-        public void initChannel(SocketChannel ch) throws Exception {
+        public void initChannel(SocketChannel ch) {
             ch.pipeline().addLast(
                     new LoggingHandler(LogLevel.DEBUG),
                     new HAProxyMessageDecoder(),
-                    new SimpleChannelInboundHandler<Object>() {
+                    new SimpleChannelInboundHandler<>() {
                         @Override
                         protected void messageReceived(ChannelHandlerContext ctx, Object msg) {
                             if (msg instanceof HAProxyMessage) {
                                 System.out.println("proxy message: " + msg);
-                            } else if (msg instanceof ByteBuf) {
-                                System.out.println("bytebuf message: " + ByteBufUtil.prettyHexDump((ByteBuf) msg));
+                            } else if (msg instanceof Buffer) {
+                                Buffer buffer = (Buffer) msg;
+                                int length = buffer.readableBytes();
+                                int rows = length / 16 + ((length & 15) == 0? 0 : 1) + 4;
+                                StringBuilder stringBuilder = new StringBuilder(rows * 80);
+                                appendPrettyHexDump(stringBuilder, buffer, buffer.readerOffset(), length);
+                                System.out.println("buffer message: " + stringBuilder);
                             }
                         }
                     });


### PR DESCRIPTION
Motivation:

Helps to have a pipeline working only with `Buffer` API

Modifications:

- Port `codec-haproxy` to `Buffer` API
- Adapt the junit tests

Result:

`codec-haproxy` now is using the `Buffer` API