### PR TITLE
Update to Netty 5.0.0.Alpha3-SNAPSHOT

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
@@ -19,9 +19,8 @@ import static java.util.Objects.requireNonNull;
 
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.Resource;
-import io.netty5.buffer.api.Send;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.util.Resource;
+import io.netty5.util.Send;
 import io.netty5.util.ByteProcessor;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
@@ -125,7 +124,7 @@ public final class HAProxyMessage implements Resource<HAProxyMessage> {
         }
 
         // Per spec, the 13th byte is the protocol version and command byte
-        header.skipReadable(12);
+        header.skipReadableBytes(12);
         final byte verCmdByte = header.readByte();
 
         HAProxyProtocolVersion ver;
@@ -182,12 +181,12 @@ public final class HAProxyMessage implements Resource<HAProxyMessage> {
             int bytes = header.openCursor(header.readerOffset(), 108).process(ByteProcessor.FIND_NUL);
             addressLen = bytes == -1 ? 108 : bytes;
             srcAddress = header.readCharSequence(addressLen, CharsetUtil.US_ASCII).toString();
-            header.skipReadable(108 - addressLen);
+            header.skipReadableBytes(108 - addressLen);
 
             bytes = header.openCursor(header.readerOffset(), 108).process(ByteProcessor.FIND_NUL);
             addressLen = bytes == -1 ? 108 : bytes;
             dstAddress = header.readCharSequence(addressLen, CharsetUtil.US_ASCII).toString();
-            header.skipReadable(108 - addressLen);
+            header.skipReadableBytes(108 - addressLen);
         } else {
             if (addressFamily == AddressFamily.AF_IPv4) {
                 // IPv4 requires 12 bytes for address information

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -381,13 +381,13 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoderForBuffer {
                         return null;
                     }
                     Buffer frame = buffer.readSplit(length);
-                    buffer.skipReadable(delimiterLength(buffer, eoh - length));
+                    buffer.skipReadableBytes(delimiterLength(buffer, eoh - length));
                     return frame;
                 } else {
                     final int length = buffer.readableBytes();
                     if (length > maxHeaderSize) {
                         discardedBytes = length;
-                        buffer.skipReadable(length);
+                        buffer.skipReadableBytes(length);
                         discarding = true;
                         if (failFast) {
                             failOverLimit(ctx, "over " + discardedBytes);
@@ -406,7 +406,7 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoderForBuffer {
                     }
                 } else {
                     discardedBytes += buffer.readableBytes();
-                    buffer.skipReadable(buffer.readableBytes());
+                    buffer.skipReadableBytes(buffer.readableBytes());
                 }
                 return null;
             }

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -138,7 +138,7 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoderForBuffer<H
             int readableBytes = value.readableBytes();
             out.writeShort((short) readableBytes);
             value.copyInto(value.readerOffset(), out, out.writerOffset(), readableBytes);
-            out.skipWritable(readableBytes);
+            out.skipWritableBytes(readableBytes);
         }
     }
 

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.haproxy;
 
 import io.netty5.bootstrap.Bootstrap;
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.buffer.api.Send;
+import io.netty5.util.Send;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -245,7 +245,7 @@ public class HaProxyMessageEncoderTest {
                 assertEquals(buffer.getUnsignedShort(14), buffer.readableBytes() - V2_HEADER_BYTES_LENGTH);
 
                 // skip to tlv section
-                buffer.skipReadable(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
+                buffer.skipReadableBytes(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
 
                 // alpn tlv
                 assertEquals(alpnTlv.typeByteValue(), buffer.readByte());
@@ -255,7 +255,7 @@ public class HaProxyMessageEncoderTest {
                     assertEquals(helloWorld, copy);
                 }
 
-                buffer.skipReadable(bufLength);
+                buffer.skipReadableBytes(bufLength);
 
                 // authority tlv
                 assertEquals(authorityTlv.typeByteValue(), buffer.readByte());
@@ -294,7 +294,7 @@ public class HaProxyMessageEncoderTest {
 
             try (Buffer buffer = ch.readOutbound()) {
                 assertEquals(buffer.getUnsignedShort(14), buffer.readableBytes() - V2_HEADER_BYTES_LENGTH);
-                buffer.skipReadable(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
+                buffer.skipReadableBytes(V2_HEADER_BYTES_LENGTH + IPv4_ADDRESS_BYTES_LENGTH);
 
                 // ssl tlv type
                 assertEquals(haProxySSLTLV.typeByteValue(), buffer.readByte());
@@ -315,7 +315,7 @@ public class HaProxyMessageEncoderTest {
                     assertEquals(helloWorld, copy);
                 }
 
-                buffer.skipReadable(bufLength);
+                buffer.skipReadableBytes(bufLength);
 
                 // authority tlv
                 assertEquals(authorityTlv.typeByteValue(), buffer.readByte());

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Alpha2-SNAPSHOT</netty.version>
+    <netty.version>5.0.0.Alpha3-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
Motivation:

Use the latest changes from Netty 5 snapshot

Modifications:

- Update to Netty 5.0.0.Alpha3-SNAPSHOT
- Adapt to the changes in the API:
  - Send/Resources moved to io.netty5.util package
  - skipReadable() -> skipReadableBytes()
  - skipWritable() -> skipWritableBytes()

Result:

Use the latest changes from Netty 5 snapshot