### PR TITLE
Update to Netty 5.0.0.Alpha3-SNAPSHOT changes

### DIFF
--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -224,7 +224,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testCloseOnInvalid() {
+    public void testCloseOnInvalid() throws InterruptedException {
         Future<Void> closeFuture = ch.closeFuture();
         String header = "GET / HTTP/1.1\r\n";
         try {
@@ -232,7 +232,7 @@ public class HAProxyMessageDecoderTest {
         } catch (HAProxyProtocolException ppex) {
             // swallow this exception since we're just testing to be sure the channel was closed
         }
-        boolean isComplete = closeFuture.awaitUninterruptibly(5000);
+        boolean isComplete = closeFuture.await(5000);
         if (!isComplete || !closeFuture.isDone() || closeFuture.isFailed()) {
             fail("Expected channel close");
         }


### PR DESCRIPTION
Motivation:

The build of the project is broken. This change is adapting the code to the changes in `Netty 5` snapshot.

Modifications:

- Remove the usage of `awaitUninterruptibly`. https://github.com/netty/netty/pull/12481

Result:

The build of the project is green again