### PR TITLE
Adapt the code to the changes in the ChannelHandler/ChannelHandlerContext methods names

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -227,8 +227,8 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoderForBuffer {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        ctx.fireExceptionCaught(cause);
+    public void channelExceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        ctx.fireChannelExceptionCaught(cause);
         if (cause instanceof HAProxyProtocolException) {
             ctx.close(); // drop connection immediately per spec
         }


### PR DESCRIPTION
Motivation:

Some of the `ChannelHandler`/`ChannelHandlerContext` methods names are changed with
 https://github.com/netty/netty/pull/12505
The code needs adaptation.

Modifications:

- `fireExceptionCaught(...)` is now `fireChannelExceptionCaught(...)`
- `exceptionCaught(...)` is now `channelExceptionCaught(...)`

Result:

The code is adapted to the new changes in the API.