### PR TITLE
HAProxyMessageDecoder/HAProxyMessageEncoder now extends ByteToMessageDecoder/MessageToByteEncoder

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -17,7 +17,7 @@ package io.netty.contrib.handler.codec.haproxy;
 
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.ByteToMessageDecoderForBuffer;
+import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.ProtocolDetectionResult;
 import io.netty5.util.CharsetUtil;
 
@@ -29,7 +29,7 @@ import static io.netty.contrib.handler.codec.haproxy.HAProxyConstants.*;
  *
  * @see <a href="https://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
  */
-public class HAProxyMessageDecoder extends ByteToMessageDecoderForBuffer {
+public class HAProxyMessageDecoder extends ByteToMessageDecoder {
     /**
      * Maximum possible length of a v1 proxy protocol header per spec
      */

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.haproxy;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
-import io.netty5.handler.codec.MessageToByteEncoderForBuffer;
+import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.CharsetUtil;
 import io.netty5.util.NetUtil;
 
@@ -32,7 +32,7 @@ import static io.netty.contrib.handler.codec.haproxy.HAProxyConstants.*;
  * @see <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
  */
 @Sharable
-public final class HAProxyMessageEncoder extends MessageToByteEncoderForBuffer<HAProxyMessage> {
+public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMessage> {
 
     private static final int V2_VERSION_BITMASK = 0x02 << 4;
 

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.contrib.handler.codec.haproxy;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.channel.ChannelHandler.Sharable;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import io.netty5.util.CharsetUtil;
@@ -31,7 +30,6 @@ import static io.netty.contrib.handler.codec.haproxy.HAProxyConstants.*;
  *
  * @see <a href="https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt">Proxy Protocol Specification</a>
  */
-@Sharable
 public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMessage> {
 
     private static final int V2_VERSION_BITMASK = 0x02 << 4;
@@ -146,5 +144,10 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
         for (int i = 0; i < haProxyTLVs.size(); i++) {
             encodeTlv(haProxyTLVs.get(i), out);
         }
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
     }
 }


### PR DESCRIPTION
Motivation:

With https://github.com/netty/netty/pull/12512
`ByteToMessageDecoderForBuffer` is renamed to `ByteToMessageDecoder`, and
`MessageToByteEncoderForBuffer` is renamed to `MessageToByteEncoder`.
The code needs adaptation.

Modifications:

- `HAProxyMessageDecoder` now extends `ByteToMessageDecoder`
- `HAProxyMessageEncoder` now extends `MessageToByteEncoder`

Result:

The code is adapted to the new changes in the API.