### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -62,13 +62,13 @@ public class HAProxyIntegrationTest {
                   });
               }
           });
-        Channel serverChannel = sb.bind(localAddress).get();
+        Channel serverChannel = sb.bind(localAddress).asStage().get();
 
         Bootstrap b = new Bootstrap();
         Channel clientChannel = b.channel(LocalChannel.class)
                                  .handler(HAProxyMessageEncoder.INSTANCE)
                                  .group(group)
-                                 .connect(localAddress).get();
+                                 .connect(localAddress).asStage().get();
 
         try {
             HAProxyMessage message = new HAProxyMessage(

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static io.netty5.buffer.BufferUtil.writeAscii;
 import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
@@ -232,7 +233,7 @@ public class HAProxyMessageDecoderTest {
         } catch (HAProxyProtocolException ppex) {
             // swallow this exception since we're just testing to be sure the channel was closed
         }
-        boolean isComplete = closeFuture.await(5000);
+        boolean isComplete = closeFuture.await(5000, TimeUnit.MILLISECONDS);
         if (!isComplete || !closeFuture.isDone() || closeFuture.isFailed()) {
             fail("Expected channel close");
         }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
@@ -42,7 +42,7 @@ public final class HAProxyClient {
              .handler(new HAProxyHandler());
 
             // Start the connection attempt.
-            Channel ch = b.connect(HOST, PORT).get();
+            Channel ch = b.connect(HOST, PORT).asStage().get();
 
             HAProxyMessage message = new HAProxyMessage(
                     HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
@@ -45,7 +45,7 @@ public final class HAProxyServer {
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HAProxyServerInitializer());
-            b.bind(PORT).get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();


### PR DESCRIPTION
Motivation:

blocking JDK Future methods have moved to FutureCompletableStage interface: see https://github.com/netty/netty/pull/12548
The code needs to be adapted.

Modifications:
- Changed _Future.get()_ to _Future.asStage().get()_
- Changed _Future.await(5000)_ to _Future.await(5000, TimeUnit.MILLISECONDS)_

Result:

The code is adapted to the new changes in the API.