### PR TITLE
Adapt to changes made in Future interface

### DIFF
--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyIntegrationTest.java
@@ -74,7 +74,7 @@ public class HAProxyIntegrationTest {
             HAProxyMessage message = new HAProxyMessage(
                     HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
                     "192.168.0.1", "192.168.0.11", 56324, 443);
-            clientChannel.writeAndFlush(message).sync();
+            clientChannel.writeAndFlush(message).asStage().sync();
 
             assertTrue(latch.await(5, TimeUnit.SECONDS));
             try (HAProxyMessage readMessage = msgHolder.get().receive()) {
@@ -87,9 +87,9 @@ public class HAProxyIntegrationTest {
                 assertEquals(message.destinationPort(), readMessage.destinationPort());
             }
         } finally {
-            clientChannel.close().sync();
-            serverChannel.close().sync();
-            group.shutdownGracefully().sync();
+            clientChannel.close().asStage().sync();
+            serverChannel.close().asStage().sync();
+            group.shutdownGracefully().asStage().sync();
         }
     }
 }

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -233,7 +233,7 @@ public class HAProxyMessageDecoderTest {
         } catch (HAProxyProtocolException ppex) {
             // swallow this exception since we're just testing to be sure the channel was closed
         }
-        boolean isComplete = closeFuture.await(5000, TimeUnit.MILLISECONDS);
+        boolean isComplete = closeFuture.asStage().await(5000, TimeUnit.MILLISECONDS);
         if (!isComplete || !closeFuture.isDone() || closeFuture.isFailed()) {
             fail("Expected channel close");
         }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyClient.java
@@ -48,10 +48,10 @@ public final class HAProxyClient {
                     HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
                     "127.0.0.1", "127.0.0.2", 8000, 9000);
 
-            ch.writeAndFlush(message).sync();
-            ch.writeAndFlush(writeAscii(ch.bufferAllocator(), "Hello World!")).sync();
-            ch.writeAndFlush(writeAscii(ch.bufferAllocator(), "Bye now!")).sync();
-            ch.close().sync();
+            ch.writeAndFlush(message).asStage().sync();
+            ch.writeAndFlush(writeAscii(ch.bufferAllocator(), "Hello World!")).asStage().sync();
+            ch.writeAndFlush(writeAscii(ch.bufferAllocator(), "Bye now!")).asStage().sync();
+            ch.close().asStage().sync();
         } finally {
             group.shutdownGracefully();
         }

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
@@ -45,7 +45,7 @@ public final class HAProxyServer {
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HAProxyServerInitializer());
-            b.bind(PORT).asStage().get().closeFuture().sync();
+            b.bind(PORT).asStage().get().closeFuture().asStage().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();


### PR DESCRIPTION
Motivation:

The `await()` (with and without timeout) and `sync()` methods have been removed
from the `Future` interface and added to the `FutureCompletionStage` interface.
https://github.com/netty/netty/pull/12569
The code needs to be adapted.

Modifications:

- Changed `Future.sync()` to `Future.asStage().sync()`
- Changed `Future.await(...)` to `Future.asStage().await(...)`

Result:

The code is adapted to the new changes in the API.