### PR TITLE
Add reflection hints for better native-image support

### DIFF
--- a/codec-haproxy/src/main/resources/META-INF/native-image/io.netty.contrib/netty-codec-haproxy/reflect-config.json
+++ b/codec-haproxy/src/main/resources/META-INF/native-image/io.netty.contrib/netty-codec-haproxy/reflect-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "io.netty.contrib.handler.codec.haproxy.HAProxyMessageDecoder",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.netty.contrib.handler.codec.haproxy.HAProxyMessageEncoder",
+    "queryAllPublicMethods": true
+  }
+]


### PR DESCRIPTION
Motivation:

When a `ChannelHandler` is added to the `Netty` channel pipeline,
`io.netty5.channel.ChannelHandlerMask#mask0` will inspect the `ChannelHandler's` methods for
`io.netty5.channel.ChannelHandlerMask.Skip` annotation.
When there are no reflection hints, `NoSuchMethodException` is thrown when trying to query the methods.
This will lead to methods marked as not skippable, although the program will be able to run
without any problems, when all methods are marked as not skippable, one might observe performance issues.

Modifications:

- Add `reflect-config.json` with configuration for various channel handlers
There is no need to add conditional configuration as this is just for querying methods, the impact on footprint should be low.

Result:

Better native-image support