### PR TITLE
Adapt to netty changes for CharsetUtil and Statics

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
@@ -22,7 +22,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.util.Resource;
 import io.netty5.util.Send;
 import io.netty5.util.ByteProcessor;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 import io.netty5.util.internal.StringUtil;
 
@@ -180,12 +180,12 @@ public final class HAProxyMessage implements Resource<HAProxyMessage> {
             }
             int bytes = header.openCursor(header.readerOffset(), 108).process(ByteProcessor.FIND_NUL);
             addressLen = bytes == -1 ? 108 : bytes;
-            srcAddress = header.readCharSequence(addressLen, CharsetUtil.US_ASCII).toString();
+            srcAddress = header.readCharSequence(addressLen, StandardCharsets.US_ASCII).toString();
             header.skipReadableBytes(108 - addressLen);
 
             bytes = header.openCursor(header.readerOffset(), 108).process(ByteProcessor.FIND_NUL);
             addressLen = bytes == -1 ? 108 : bytes;
-            dstAddress = header.readCharSequence(addressLen, CharsetUtil.US_ASCII).toString();
+            dstAddress = header.readCharSequence(addressLen, StandardCharsets.US_ASCII).toString();
             header.skipReadableBytes(108 - addressLen);
         } else {
             if (addressFamily == AddressFamily.AF_IPv4) {
@@ -412,7 +412,7 @@ public final class HAProxyMessage implements Resource<HAProxyMessage> {
                 return;
             case AF_UNIX:
                 requireNonNull(address, "address");
-                if (address.getBytes(CharsetUtil.US_ASCII).length > 108) {
+                if (address.getBytes(StandardCharsets.US_ASCII).length > 108) {
                     throw new IllegalArgumentException("invalid AF_UNIX address: " + address);
                 }
                 return;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -19,8 +19,7 @@ import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.ProtocolDetectionResult;
-import io.netty5.util.CharsetUtil;
-
+import java.nio.charset.StandardCharsets;
 
 import static io.netty.contrib.handler.codec.haproxy.HAProxyConstants.*;
 
@@ -255,7 +254,7 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
             finished = true;
             try {
                 if (version == 1) {
-                    ctx.fireChannelRead(HAProxyMessage.decodeHeader(decoded.toString(CharsetUtil.US_ASCII)));
+                    ctx.fireChannelRead(HAProxyMessage.decodeHeader(decoded.toString(StandardCharsets.US_ASCII)));
                 } else {
                     ctx.fireChannelRead(HAProxyMessage.decodeHeader(decoded));
                 }

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.haproxy;
 import io.netty5.buffer.api.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.NetUtil;
 
 import java.util.List;
@@ -65,15 +65,15 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
     private static void encodeV1(HAProxyMessage msg, Buffer out) {
         out.writeBytes(TEXT_PREFIX);
         out.writeByte((byte) ' ');
-        out.writeCharSequence(msg.proxiedProtocol().name(), CharsetUtil.US_ASCII);
+        out.writeCharSequence(msg.proxiedProtocol().name(), StandardCharsets.US_ASCII);
         out.writeByte((byte) ' ');
-        out.writeCharSequence(msg.sourceAddress(), CharsetUtil.US_ASCII);
+        out.writeCharSequence(msg.sourceAddress(), StandardCharsets.US_ASCII);
         out.writeByte((byte) ' ');
-        out.writeCharSequence(msg.destinationAddress(), CharsetUtil.US_ASCII);
+        out.writeCharSequence(msg.destinationAddress(), StandardCharsets.US_ASCII);
         out.writeByte((byte) ' ');
-        out.writeCharSequence(String.valueOf(msg.sourcePort()), CharsetUtil.US_ASCII);
+        out.writeCharSequence(String.valueOf(msg.sourcePort()), StandardCharsets.US_ASCII);
         out.writeByte((byte) ' ');
-        out.writeCharSequence(String.valueOf(msg.destinationPort()), CharsetUtil.US_ASCII);
+        out.writeCharSequence(String.valueOf(msg.destinationPort()), StandardCharsets.US_ASCII);
         out.writeByte((byte) '\r');
         out.writeByte((byte) '\n');
     }
@@ -99,14 +99,14 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
             case AF_UNIX:
                 out.writeShort((short) (TOTAL_UNIX_ADDRESS_BYTES_LENGTH + msg.tlvNumBytes()));
                 int srcAddrBytesWritten = out.writerOffset();
-                out.writeCharSequence(msg.sourceAddress(), CharsetUtil.US_ASCII);
+                out.writeCharSequence(msg.sourceAddress(), StandardCharsets.US_ASCII);
                 srcAddrBytesWritten = out.writerOffset() - srcAddrBytesWritten;
                 int length = UNIX_ADDRESS_BYTES_LENGTH - srcAddrBytesWritten;
                 for(int i = 0; i < length; ++i) {
                     out.writeByte((byte) 0);
                 }
                 int dstAddrBytesWritten = out.writerOffset();
-                out.writeCharSequence(msg.destinationAddress(), CharsetUtil.US_ASCII);
+                out.writeCharSequence(msg.destinationAddress(), StandardCharsets.US_ASCII);
                 dstAddrBytesWritten = out.writerOffset() - dstAddrBytesWritten;
                 length = UNIX_ADDRESS_BYTES_LENGTH - dstAddrBytesWritten;
                 for(int i = 0; i < length; ++i) {

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -21,7 +21,7 @@ import io.netty5.handler.codec.ProtocolDetectionResult;
 import io.netty5.handler.codec.ProtocolDetectionState;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.TransportProtocol;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import io.netty5.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -687,14 +687,14 @@ public class HAProxyMessageDecoderTest {
             Buffer secondContentBuf = secondTlv.content();
             byte[] secondContent = new byte[secondContentBuf.readableBytes()];
             secondContentBuf.readBytes(secondContent, 0, secondContent.length);
-            assertArrayEquals("TLSv1".getBytes(CharsetUtil.US_ASCII), secondContent);
+            assertArrayEquals("TLSv1".getBytes(StandardCharsets.US_ASCII), secondContent);
 
             final HAProxyTLV thirdTLV = tlvs.get(2);
             assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL_CN, thirdTLV.type());
             Buffer thirdContentBuf = thirdTLV.content();
             byte[] thirdContent = new byte[thirdContentBuf.readableBytes()];
             thirdContentBuf.readBytes(thirdContent, 0, thirdContent.length);
-            assertArrayEquals("LEAF".getBytes(CharsetUtil.US_ASCII), thirdContent);
+            assertArrayEquals("LEAF".getBytes(StandardCharsets.US_ASCII), thirdContent);
 
             assertTrue(sslTlv.encapsulatedTLVs().contains(secondTlv));
             assertTrue(sslTlv.encapsulatedTLVs().contains(thirdTLV));

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -16,11 +16,11 @@
 package io.netty.contrib.handler.codec.haproxy;
 
 import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.internal.Statics;
+import io.netty5.buffer.api.internal.InternalBufferUtils;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty.contrib.handler.codec.haproxy.HAProxyTLV.Type;
 import io.netty5.util.ByteProcessor;
-import io.netty5.util.CharsetUtil;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -53,7 +53,7 @@ public class HaProxyMessageEncoderTest {
 
         try (Buffer buffer = ch.readOutbound()) {
             assertEquals("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n",
-                    buffer.toString(CharsetUtil.US_ASCII));
+                    buffer.toString(StandardCharsets.US_ASCII));
         }
         assertFalse(ch.finish());
     }
@@ -69,7 +69,7 @@ public class HaProxyMessageEncoderTest {
 
         try (Buffer buffer = ch.readOutbound()) {
             assertEquals("PROXY TCP6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n",
-                    buffer.toString(CharsetUtil.US_ASCII));
+                    buffer.toString(StandardCharsets.US_ASCII));
         }
         assertFalse(ch.finish());
     }
@@ -212,11 +212,11 @@ public class HaProxyMessageEncoderTest {
 
             // source address
             int bytes = buffer.openCursor(16, 108).process(ByteProcessor.FIND_NUL);
-            assertEquals("/var/run/src.sock", Statics.copyToCharSequence(buffer, 16, bytes, CharsetUtil.US_ASCII));
+            assertEquals("/var/run/src.sock", InternalBufferUtils.copyToCharSequence(buffer, 16, bytes, StandardCharsets.US_ASCII));
 
             // destination address
             bytes = buffer.openCursor(124, 108).process(ByteProcessor.FIND_NUL);
-            assertEquals("/var/run/dst.sock", Statics.copyToCharSequence(buffer, 124, bytes, CharsetUtil.US_ASCII));
+            assertEquals("/var/run/dst.sock", InternalBufferUtils.copyToCharSequence(buffer, 124, bytes, StandardCharsets.US_ASCII));
         }
         assertFalse(ch.finish());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
   </developers>
 
   <properties>
-    <netty.version>5.0.0.Alpha3</netty.version>
+    <netty.version>5.0.0.Alpha5-SNAPSHOT</netty.version>
     <netty.build.version>29</netty.build.version>
     <project.scm.id>github</project.scm.id>
     <release.gpg.keyname />


### PR DESCRIPTION
**Motivation:**

We need to adapt to the following netty PR changes:

Rename Statics to InternalBufferUtils (https://github.com/netty/netty/pull/12739)
Remove Charset constants from CharsetUtil (https://github.com/netty/netty/pull/12741)

**Modification:**

Netty CharsetUtil needs to be replaced by java.nio.charset.StandardCharsets and Statics by InternalBufferUtils
Also, the netty.version has been updated from  5.0.0.Alpha3 to 5.0.0.Alpha5-SNAPSHOT

**Result:**

The codec-haproxy can now be built using latest 5.0.0.Alpha5-SNAPSHOT and this will unblock the Reactor-Netty build based on netty5