### PR TITLE
Adapt to the changed package for Buffer API

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessage.java
@@ -18,7 +18,7 @@ package io.netty.contrib.handler.codec.haproxy;
 import static java.util.Objects.requireNonNull;
 
 import io.netty.contrib.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.util.Resource;
 import io.netty5.util.Send;
 import io.netty5.util.ByteProcessor;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.ByteToMessageDecoder;
 import io.netty5.handler.codec.ProtocolDetectionResult;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.handler.codec.MessageToByteEncoder;
 import java.nio.charset.StandardCharsets;

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLV.java
@@ -15,13 +15,13 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.util.internal.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 
 /**
  * Represents a {@link HAProxyTLV} of the type {@link HAProxyTLV.Type#PP2_TYPE_SSL}.

--- a/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/contrib/handler/codec/haproxy/HAProxyTLV.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.BufferHolder;
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.BufferHolder;
 import io.netty5.util.internal.StringUtil;
 
 import static java.util.Objects.requireNonNull;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -15,7 +15,7 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.handler.codec.ProtocolDetectionResult;
 import io.netty5.handler.codec.ProtocolDetectionState;
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty5.buffer.BufferUtil.writeAscii;
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static io.netty5.buffer.api.DefaultBufferAllocators.preferredAllocator;
+import static io.netty5.buffer.DefaultBufferAllocators.preferredAllocator;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -15,8 +15,8 @@
  */
 package io.netty.contrib.handler.codec.haproxy;
 
-import io.netty5.buffer.api.Buffer;
-import io.netty5.buffer.api.internal.InternalBufferUtils;
+import io.netty5.buffer.Buffer;
+import io.netty5.buffer.internal.InternalBufferUtils;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty.contrib.handler.codec.haproxy.HAProxyTLV.Type;
 import io.netty5.util.ByteProcessor;

--- a/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/NativeImageHandlerMetadataTest.java
+++ b/codec-haproxy/src/test/java/io/netty/contrib/handler/codec/haproxy/NativeImageHandlerMetadataTest.java
@@ -23,7 +23,7 @@ public class NativeImageHandlerMetadataTest {
     @Test
     public void collectAndCompareMetadata() {
         ChannelHandlerMetadataUtil.generateMetadata(
-                "src/main/resources/META-INF/native-image/io.netty.contrib/netty-codec-haproxy/reflect-config.json",
+                "io.netty.contrib/netty-codec-haproxy/reflect-config.json",
                 "io.netty.contrib.handler.codec.haproxy");
     }
 

--- a/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
+++ b/examples/src/main/java/io/netty/contrib/handler/codec/haproxy/example/HAProxyServer.java
@@ -16,7 +16,7 @@
 package io.netty.contrib.handler.codec.haproxy.example;
 
 import io.netty5.bootstrap.ServerBootstrap;
-import io.netty5.buffer.api.Buffer;
+import io.netty5.buffer.Buffer;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.channel.EventLoopGroup;


### PR DESCRIPTION
Motivation:
- Buffer API package was changed from `io.netty5.buffer.api` to `io.netty5.buffer` https://github.com/netty/netty/pull/12792
- Small enhancement was introduced to `ChannelHandlerMetadataUtil` https://github.com/netty/netty/pull/12786

Modification:
- Adapt to the changed package for Buffer API
- Adapt to the change in `ChannelHandlerMetadataUtil`

Result:
Project build is green again